### PR TITLE
Fix deprecation warning in pandas .isin() by casting holiday dates to…

### DIFF
--- a/src/long_weekends/long_weekends.py
+++ b/src/long_weekends/long_weekends.py
@@ -41,7 +41,7 @@ def spot_holiday_bridges(start: Union[str, date],
     # compute is_weekend
     is_weekend = dow.isin([5, 6])
     # compute is_holiday
-    is_holiday = dates.isin(holidays)
+    is_holiday = dates.isin(pd.DatetimeIndex(holidays.keys()))
     # compute union of weekends and holidays
     is_non_working = is_weekend | is_holiday
     # spot bridges


### PR DESCRIPTION
### Summary
This pull request resolves a deprecation warning in pandas related to the use of `.isin()` with `datetime64[ns]` and `datetime.date` objects. The warning occurs when comparing a pandas `DatetimeIndex` with a dictionary of holiday dates stored as `datetime.date`.

### Changes
- Explicitly cast the holiday date keys to `DatetimeIndex` using `pd.DatetimeIndex(holidays.keys())` before performing the `.isin()` check.
  
### Impact
This fix ensures compatibility with future pandas versions, preventing unexpected behavior from the deprecated implicit casting.

